### PR TITLE
Document core discussion process

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ Meeting agendas are available under the "agenda" label in the issue queue here p
 Current attendees are:
 * guybedford (Guy Bedford)
 * JayaKrishnaNamburu
-* vovacodes
+* vovacodes (Vova Guguiev)
 * jollytoad

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If it turns out to be a bug, the package will be fixed as soon as possible with 
 
 # JSPM Core Discussion
 
-Core project discussions are held every two weeks on a Thursday, 12pm Pacific Time, covering the current status and roadmap for the project as a whole.
+Core project discussions are held every two weeks on a Thursday, 9am Pacific Time, covering the current status and roadmap for the project as a whole.
 
 Anyone may attend or propose topics for the agenda so long as they are relevant to the core project discussion.
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,19 @@ All issues for the jspm CDN can be posted here (https://github.com/jspm/project/
 Every attempt will be made to fix bugs promptly, so if you suspect a CDN bug please do write up the case.
 
 If it turns out to be a bug, the package will be fixed as soon as possible with the relevant CDN cache paths flushed.
+
+# JSPM Core Discussion
+
+Core project discussions are held every two weeks on a Thursday, 12pm Pacific Time, covering the current status and roadmap for the project as a whole.
+
+Anyone may attend or propose topics for the agenda so long as they are relevant to the core project discussion.
+
+To receive an invite, post an issue to this repo with the title "Meeting Invite" and your name.
+
+Meeting agendas are available under the "agenda" label in the issue queue here prior to each meeting.
+
+Current attendees are:
+* guybedford (Guy Bedford)
+* JayaKrishnaNamburu
+* vovacodes
+* jollytoad

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Current attendees are:
 * guybedford (Guy Bedford)
 * JayaKrishnaNamburu
 * vovacodes (Vova Guguiev)
-* jollytoad
+* jollytoad (Mark Gibson)


### PR DESCRIPTION
This adds a section to the project readme detailing the core discussion meetings and some basic process.

I've included the names of attendees as well here. @JayaKrishnaNamburu @vovacodes @jollytoad if you would prefer not to be listed please let me know - that would be completely understandable. Also if you want to provide a name you wish to be referred by feel free to comment further as well.

I won't merge this in until I've got confirmation though.

Any futher suggestions welcome.